### PR TITLE
Task-2791 rename serveles function bservice -> service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ clean:
 	rm -rf ./bin ./vendor 
 
 offline: build
-	yarn sls offline --stage ${environment} --httpPort 3009 --noTimeout
+	yarn sls offline --stage ${environment} --noTimeout
 
 deploy: clean build
 	sls deploy --stage ${environment} 
@@ -28,6 +28,6 @@ gomodgen:
 GO_ENV=GOARCH=${GOARCH} GOOS=${GOOS} CGO_ENABLED=0
 
 create-build:
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -tags lambda.norpc -o bootstrap cmd/httpserver/api/main.go
+	env ${GO_ENV} go build -tags lambda.norpc -o bootstrap cmd/httpserver/api/main.go
 vet:
 	go vet ./...

--- a/serverless.yml
+++ b/serverless.yml
@@ -42,10 +42,10 @@ package:
   patterns:
     - "!./**"
     - ./bin/**
-    - "./bootstrap" # include the root-level bootstrap binary
+    - "./bootstrap" # include the root-level bootstrap binary.
 
 functions:
-  bservice:
+  service:
     url: true
     handler: bootstrap
     timeout: 10
@@ -69,6 +69,8 @@ custom:
     prod: provided.al2023
   serverless-offline:
     useDocker: true
+    host: 0.0.0.0
+    httpPort: 3009
     lambdaPort: 8080
     lambdaHost: lambda # resolves to the `lambda` service in Docker Compose
     dockerHost: host.docker.internal


### PR DESCRIPTION
# Description
Rename serverless function bservice -> service and improve the serverless-offline environment.

# Task
https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2791

# Test
- Successfully deployed to production environment with the AL2023 runtime